### PR TITLE
updated go-sdk-symbols to v0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/taubyte/go-sdk
 go 1.18
 
 // Direct Taubyte imports
-require github.com/taubyte/go-sdk-symbols v0.1.2
+require github.com/taubyte/go-sdk-symbols v0.1.3
 
 // Direct imports
 require (

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/taubyte/go-sdk-symbols v0.1.2 h1:vDVYcDoCU/QXBKGZdnEyjrkmpYTVEqMBQtXlwYmU3hI=
-github.com/taubyte/go-sdk-symbols v0.1.2/go.mod h1:aaLvDq/dtRyPyNoAOcKH85GjYqAZDC3ZFrSUS3TKum8=
+github.com/taubyte/go-sdk-symbols v0.1.3 h1:TsBuCLA4YJFKaEgGVAMgtx0hhNUYAkn/EJ6xD98qNQQ=
+github.com/taubyte/go-sdk-symbols v0.1.3/go.mod h1:aaLvDq/dtRyPyNoAOcKH85GjYqAZDC3ZFrSUS3TKum8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=


### PR DESCRIPTION
Updated go-sdk-symbols version to include the go-build tags for the mocked symbols